### PR TITLE
Add truststore to ipaas-rest to be able to validate keycloak route and ensure CORS origins are correct

### DIFF
--- a/redhat-ipaas-dev-single-tenant.yml
+++ b/redhat-ipaas-dev-single-tenant.yml
@@ -277,7 +277,40 @@ objects:
           app: redhat-ipaas
           component: ipaas-rest
           deploymentconfig: ipaas-rest
+        annotations:
+          pod.beta.kubernetes.io/init-containers: |-
+            [{
+              "name": "openshift-ca-pemtokeystore",
+              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "imagePullPolicy": "IfNotPresent",
+              "args": [
+                "-keystore", "/tls-keystore/openshift-truststore.jks",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+                "-ca-dir", "/usr/share/ca-certificates/mozilla"
+              ],
+              "volumeMounts": [{
+                "name": "ipaas-rest-tls",
+                "mountPath": "/tls-keystore"
+              }]
+            }]
       spec:
+        initContainers:
+        - name: openshift-ca-pemtokeystore
+          image: ${PEMTOKEYSTORE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+          - -keystore
+          - /tls-keystore/openshift-truststore.jks
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - -ca-dir
+          - /usr/share/ca-certificates/mozilla
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
         serviceAccountName: ipaas-rest
         containers:
         - name: ipaas-rest
@@ -289,7 +322,7 @@ objects:
           - name: AB_OFF
             value: "true"
           - name: JAVA_OPTIONS
-            value: "-Djava.net.preferIPv4Stack=true"
+            value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks"
           image: rhipaas/ipaas-rest:latest
           imagePullPolicy: ${IMAGE_PULL_POLICY}
           readinessProbe:
@@ -304,6 +337,11 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
           resources:
             limits:
               cpu: 2000m
@@ -311,6 +349,12 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+        volumes:
+        - name: ipaas-rest-tls
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: ipaas-rest-config
     triggers:
     - type: ConfigChange
 - apiVersion: v1
@@ -1429,4 +1473,51 @@ objects:
           "hybrid": true,
           "issuer": "https://${ROUTE_HOSTNAME}/auth/realms/${KEYCLOAK_IPAAS_REALM_NAME}"
         }
+      }
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: redhat-ipaas
+      component: ipaas-rest
+    name: ipaas-rest-config
+  data:
+    application.yml: |-
+      deployment:
+        file: com/redhat/ipaas/api/v1/deployment.json
+      resteasy:
+        jaxrs:
+          app:
+            registration: property
+            classes: com.redhat.ipaas.api.v1.rest.V1Application
+      cors:
+        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+      cache:
+        cluster:
+          name: IPaaSCluster
+        max:
+          entries: 100
+      spring:
+        zipkin:
+          enabled: false
+      security:
+        basic:
+          enabled: false
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
+      keycloak:
+        enabled: true
+        configurationFile: file:config/ipaas-client.json
+    ipaas-client.json: |-
+      {
+        "realm": "${KEYCLOAK_IPAAS_REALM_NAME}",
+        "bearer-only": true,
+        "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
+        "ssl-required": "external",
+        "resource": "ipaas-rest"
       }

--- a/redhat-ipaas-dev.yml
+++ b/redhat-ipaas-dev.yml
@@ -277,7 +277,40 @@ objects:
           app: redhat-ipaas
           component: ipaas-rest
           deploymentconfig: ipaas-rest
+        annotations:
+          pod.beta.kubernetes.io/init-containers: |-
+            [{
+              "name": "openshift-ca-pemtokeystore",
+              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "imagePullPolicy": "IfNotPresent",
+              "args": [
+                "-keystore", "/tls-keystore/openshift-truststore.jks",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+                "-ca-dir", "/usr/share/ca-certificates/mozilla"
+              ],
+              "volumeMounts": [{
+                "name": "ipaas-rest-tls",
+                "mountPath": "/tls-keystore"
+              }]
+            }]
       spec:
+        initContainers:
+        - name: openshift-ca-pemtokeystore
+          image: ${PEMTOKEYSTORE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+          - -keystore
+          - /tls-keystore/openshift-truststore.jks
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - -ca-dir
+          - /usr/share/ca-certificates/mozilla
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
         serviceAccountName: ipaas-rest
         containers:
         - name: ipaas-rest
@@ -289,7 +322,7 @@ objects:
           - name: AB_OFF
             value: "true"
           - name: JAVA_OPTIONS
-            value: "-Djava.net.preferIPv4Stack=true"
+            value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks"
           image: rhipaas/ipaas-rest:latest
           imagePullPolicy: ${IMAGE_PULL_POLICY}
           readinessProbe:
@@ -304,6 +337,11 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
           resources:
             limits:
               cpu: 2000m
@@ -311,6 +349,12 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+        volumes:
+        - name: ipaas-rest-tls
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: ipaas-rest-config
     triggers:
     - type: ConfigChange
 - apiVersion: v1
@@ -1440,4 +1484,50 @@ objects:
   secret: ${OPENSHIFT_OAUTH_CLIENT_SECRET}
   redirectURIs:
   - https://${ROUTE_HOSTNAME}/auth/realms/${KEYCLOAK_IPAAS_REALM_NAME}
-  grantMethod: prompt
+  grantMethod: prompt- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: redhat-ipaas
+      component: ipaas-rest
+    name: ipaas-rest-config
+  data:
+    application.yml: |-
+      deployment:
+        file: com/redhat/ipaas/api/v1/deployment.json
+      resteasy:
+        jaxrs:
+          app:
+            registration: property
+            classes: com.redhat.ipaas.api.v1.rest.V1Application
+      cors:
+        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+      cache:
+        cluster:
+          name: IPaaSCluster
+        max:
+          entries: 100
+      spring:
+        zipkin:
+          enabled: false
+      security:
+        basic:
+          enabled: false
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
+      keycloak:
+        enabled: true
+        configurationFile: file:config/ipaas-client.json
+    ipaas-client.json: |-
+      {
+        "realm": "${KEYCLOAK_IPAAS_REALM_NAME}",
+        "bearer-only": true,
+        "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
+        "ssl-required": "external",
+        "resource": "ipaas-rest"
+      }

--- a/redhat-ipaas-single-tenant.yml
+++ b/redhat-ipaas-single-tenant.yml
@@ -334,7 +334,40 @@ objects:
           app: redhat-ipaas
           component: ipaas-rest
           deploymentconfig: ipaas-rest
+        annotations:
+          pod.beta.kubernetes.io/init-containers: |-
+            [{
+              "name": "openshift-ca-pemtokeystore",
+              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "imagePullPolicy": "IfNotPresent",
+              "args": [
+                "-keystore", "/tls-keystore/openshift-truststore.jks",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+                "-ca-dir", "/usr/share/ca-certificates/mozilla"
+              ],
+              "volumeMounts": [{
+                "name": "ipaas-rest-tls",
+                "mountPath": "/tls-keystore"
+              }]
+            }]
       spec:
+        initContainers:
+        - name: openshift-ca-pemtokeystore
+          image: ${PEMTOKEYSTORE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+          - -keystore
+          - /tls-keystore/openshift-truststore.jks
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - -ca-dir
+          - /usr/share/ca-certificates/mozilla
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
         serviceAccountName: ipaas-rest
         containers:
         - name: ipaas-rest
@@ -346,7 +379,7 @@ objects:
           - name: AB_OFF
             value: "true"
           - name: JAVA_OPTIONS
-            value: "-Djava.net.preferIPv4Stack=true"
+            value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks"
           image: ' '
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -361,6 +394,11 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
           resources:
             limits:
               cpu: 2000m
@@ -368,6 +406,12 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+        volumes:
+        - name: ipaas-rest-tls
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: ipaas-rest-config
     triggers:
     - imageChangeParams:
         automatic: true
@@ -1494,4 +1538,51 @@ objects:
           "hybrid": true,
           "issuer": "https://${ROUTE_HOSTNAME}/auth/realms/${KEYCLOAK_IPAAS_REALM_NAME}"
         }
+      }
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: redhat-ipaas
+      component: ipaas-rest
+    name: ipaas-rest-config
+  data:
+    application.yml: |-
+      deployment:
+        file: com/redhat/ipaas/api/v1/deployment.json
+      resteasy:
+        jaxrs:
+          app:
+            registration: property
+            classes: com.redhat.ipaas.api.v1.rest.V1Application
+      cors:
+        allowedOrigins: https://${ROUTE_HOSTNAME}
+      cache:
+        cluster:
+          name: IPaaSCluster
+        max:
+          entries: 100
+      spring:
+        zipkin:
+          enabled: false
+      security:
+        basic:
+          enabled: false
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
+      keycloak:
+        enabled: true
+        configurationFile: file:config/ipaas-client.json
+    ipaas-client.json: |-
+      {
+        "realm": "${KEYCLOAK_IPAAS_REALM_NAME}",
+        "bearer-only": true,
+        "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
+        "ssl-required": "external",
+        "resource": "ipaas-rest"
       }

--- a/redhat-ipaas.yml
+++ b/redhat-ipaas.yml
@@ -250,8 +250,7 @@ objects:
           - name: ipaas-keycloak-tls
             mountPath: /tls-keystore
         containers:
-        - name: ipaas-keycloak
-          args:
+        - args:
           - -b
           - 0.0.0.0
           - -Dkeycloak.import=/opt/jboss/keycloak/standalone/configuration/ipaas-realm.json
@@ -269,6 +268,7 @@ objects:
                 key: password
                 name: ipaas-keycloak-admin
           image: ' '
+          name: ipaas-keycloak
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
@@ -334,7 +334,40 @@ objects:
           app: redhat-ipaas
           component: ipaas-rest
           deploymentconfig: ipaas-rest
+        annotations:
+          pod.beta.kubernetes.io/init-containers: |-
+            [{
+              "name": "openshift-ca-pemtokeystore",
+              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "imagePullPolicy": "IfNotPresent",
+              "args": [
+                "-keystore", "/tls-keystore/openshift-truststore.jks",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                "-ca-file", "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt",
+                "-ca-dir", "/usr/share/ca-certificates/mozilla"
+              ],
+              "volumeMounts": [{
+                "name": "ipaas-rest-tls",
+                "mountPath": "/tls-keystore"
+              }]
+            }]
       spec:
+        initContainers:
+        - name: openshift-ca-pemtokeystore
+          image: ${PEMTOKEYSTORE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          args:
+          - -keystore
+          - /tls-keystore/openshift-truststore.jks
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          - -ca-file
+          - /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+          - -ca-dir
+          - /usr/share/ca-certificates/mozilla
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
         serviceAccountName: ipaas-rest
         containers:
         - name: ipaas-rest
@@ -346,7 +379,7 @@ objects:
           - name: AB_OFF
             value: "true"
           - name: JAVA_OPTIONS
-            value: "-Djava.net.preferIPv4Stack=true"
+            value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks"
           image: ' '
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -361,6 +394,11 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          volumeMounts:
+          - name: ipaas-rest-tls
+            mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
           resources:
             limits:
               cpu: 2000m
@@ -368,6 +406,12 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+        volumes:
+        - name: ipaas-rest-tls
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: ipaas-rest-config
     triggers:
     - imageChangeParams:
         automatic: true
@@ -1506,3 +1550,50 @@ objects:
   redirectURIs:
   - https://${ROUTE_HOSTNAME}/auth/realms/${KEYCLOAK_IPAAS_REALM_NAME}
   grantMethod: prompt
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: redhat-ipaas
+      component: ipaas-rest
+    name: ipaas-rest-config
+  data:
+    application.yml: |-
+      deployment:
+        file: com/redhat/ipaas/api/v1/deployment.json
+      resteasy:
+        jaxrs:
+          app:
+            registration: property
+            classes: com.redhat.ipaas.api.v1.rest.V1Application
+      cors:
+        allowedOrigins: https://${ROUTE_HOSTNAME}
+      cache:
+        cluster:
+          name: IPaaSCluster
+        max:
+          entries: 100
+      spring:
+        zipkin:
+          enabled: false
+      security:
+        basic:
+          enabled: false
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
+      keycloak:
+        enabled: true
+        configurationFile: file:config/ipaas-client.json
+    ipaas-client.json: |-
+      {
+        "realm": "${KEYCLOAK_IPAAS_REALM_NAME}",
+        "bearer-only": true,
+        "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
+        "ssl-required": "external",
+        "resource": "ipaas-rest"
+      }


### PR DESCRIPTION
@dsimansk Could you take a look please? If you have time to try one of these before we merge out that would be awesome.