### PR TITLE
Add param  to disable strict cert validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Once all pods are started up, you should be able to access the iPaaS at `https:/
 * `KEYCLOAK_ADMIN_PASSWORD`: The Keycloak admin password
 * `KEYCLOAK_IPAAS_REALM_NAME`: iPaaS Keycloak realm name
 * `KEYCLOAK_IPAAS_REST_CLIENT_SECRET`: iPaaS REST service client secret
+* `KEYCLOAK_ALLOW_ANY_HOSTNAME`: The Keycloack parameter to disable hostname validation on certificate
 * `OPENSHIFT_MASTER`: Public OpenShift master address
 * `OPENSHIFT_OAUTH_CLIENT_ID`: OpenShift OAuth client ID
 * `OPENSHIFT_OAUTH_CLIENT_SECRET`: OpenShift OAuth client secret

--- a/redhat-ipaas-dev-single-tenant.yml
+++ b/redhat-ipaas-dev-single-tenant.yml
@@ -28,6 +28,10 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- name: KEYCLOAK_ALLOW_ANY_HOSTNAME
+  description: The Keycloack parameter to disable hostname validation on certificate
+  value: "true"
+  required: true
 - name: OPENSHIFT_MASTER
   description: Public OpenShift master address
   value: https://localhost:8443
@@ -1520,5 +1524,5 @@ objects:
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
         "resource": "ipaas-rest",
-        "allow-any-hostname" : true
+        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
       }

--- a/redhat-ipaas-dev-single-tenant.yml
+++ b/redhat-ipaas-dev-single-tenant.yml
@@ -1524,5 +1524,5 @@ objects:
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
         "resource": "ipaas-rest",
-        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
+        "allow-any-hostname" : ${KEYCLOAK_ALLOW_ANY_HOSTNAME}
       }

--- a/redhat-ipaas-dev-single-tenant.yml
+++ b/redhat-ipaas-dev-single-tenant.yml
@@ -1519,5 +1519,6 @@ objects:
         "bearer-only": true,
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
-        "resource": "ipaas-rest"
+        "resource": "ipaas-rest",
+        "allow-any-hostname" : true
       }

--- a/redhat-ipaas-dev.yml
+++ b/redhat-ipaas-dev.yml
@@ -1529,5 +1529,6 @@ objects:
         "bearer-only": true,
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
-        "resource": "ipaas-rest"
+        "resource": "ipaas-rest",
+        "allow-any-hostname" : true
       }

--- a/redhat-ipaas-dev.yml
+++ b/redhat-ipaas-dev.yml
@@ -28,6 +28,10 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- name: KEYCLOAK_ALLOW_ANY_HOSTNAME
+  description: The Keycloack parameter to disable hostname validation on certificate
+  value: "true"
+  required: true
 - name: OPENSHIFT_MASTER
   description: Public OpenShift master address
   value: https://localhost:8443
@@ -1530,5 +1534,5 @@ objects:
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
         "resource": "ipaas-rest",
-        "allow-any-hostname" : true
+        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
       }

--- a/redhat-ipaas-dev.yml
+++ b/redhat-ipaas-dev.yml
@@ -1534,5 +1534,5 @@ objects:
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
         "resource": "ipaas-rest",
-        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
+        "allow-any-hostname" : ${KEYCLOAK_ALLOW_ANY_HOSTNAME}
       }

--- a/redhat-ipaas-single-tenant.yml
+++ b/redhat-ipaas-single-tenant.yml
@@ -1589,5 +1589,5 @@ objects:
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
         "resource": "ipaas-rest",
-        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
+        "allow-any-hostname" : ${KEYCLOAK_ALLOW_ANY_HOSTNAME}
       }

--- a/redhat-ipaas-single-tenant.yml
+++ b/redhat-ipaas-single-tenant.yml
@@ -28,6 +28,10 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- name: KEYCLOAK_ALLOW_ANY_HOSTNAME
+  description: The Keycloack parameter to disable hostname validation on certificate
+  value: "false"
+  required: true
 - name: OPENSHIFT_MASTER
   description: Public OpenShift master address
   value: https://localhost:8443
@@ -1584,5 +1588,6 @@ objects:
         "bearer-only": true,
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
-        "resource": "ipaas-rest"
+        "resource": "ipaas-rest",
+        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
       }

--- a/redhat-ipaas.yml
+++ b/redhat-ipaas.yml
@@ -1600,5 +1600,5 @@ objects:
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
         "resource": "ipaas-rest",
-        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
+        "allow-any-hostname" : ${KEYCLOAK_ALLOW_ANY_HOSTNAME}
       }

--- a/redhat-ipaas.yml
+++ b/redhat-ipaas.yml
@@ -28,6 +28,10 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
+- name: KEYCLOAK_ALLOW_ANY_HOSTNAME
+  description: The Keycloack parameter to disable hostname validation on certificate
+  value: "false"
+  required: true
 - name: OPENSHIFT_MASTER
   description: Public OpenShift master address
   value: https://localhost:8443
@@ -1595,5 +1599,6 @@ objects:
         "bearer-only": true,
         "auth-server-url": "https://${ROUTE_HOSTNAME}/auth",
         "ssl-required": "external",
-        "resource": "ipaas-rest"
+        "resource": "ipaas-rest",
+        "allow-any-hostname" : "${KEYCLOAK_ALLOW_ANY_HOSTNAME}"
       }


### PR DESCRIPTION
Keycloak param `allow-any-hostname" : true` [per docs](http://www.keycloak.org/docs/2.5/securing_apps_guide/topics/oidc/java/java-adapter-config.html).

@jimmidyson added to `*-dev` templates. If it should go to all of them, just let me know. 