### PR TITLE
Add ipaas:admins rolebinding.

### DIFF
--- a/redhat-ipaas-dev-single-tenant.yml
+++ b/redhat-ipaas-dev-single-tenant.yml
@@ -130,6 +130,26 @@ objects:
   - kind: ServiceAccount
     name: ipaas-rest
 - apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: ipaas:admins
+    labels:
+      app: redhat-ipaas
+roleRef:
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: ipaas-deployer
+  namespace: ipaas-staging
+- kind: ServiceAccount
+  name: jenkins
+  namespace: ipaas-ci
+- kind: Group
+  name: dedicated-admins
+userNames:
+- system:serviceaccount:ipaas-staging:ipaas-deployer
+- system:serviceaccount:ipaas-ci:jenkins
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:

--- a/redhat-ipaas-single-tenant.yml
+++ b/redhat-ipaas-single-tenant.yml
@@ -186,6 +186,26 @@ objects:
   - kind: ServiceAccount
     name: ipaas-rest
 - apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: ipaas:admins
+    labels:
+      app: redhat-ipaas
+roleRef:
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: ipaas-deployer
+  namespace: ipaas-staging
+- kind: ServiceAccount
+  name: jenkins
+  namespace: ipaas-ci
+- kind: Group
+  name: dedicated-admins
+userNames:
+- system:serviceaccount:ipaas-staging:ipaas-deployer
+- system:serviceaccount:ipaas-ci:jenkins
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:

--- a/redhat-ipaas.yml
+++ b/redhat-ipaas.yml
@@ -186,6 +186,26 @@ objects:
   - kind: ServiceAccount
     name: ipaas-rest
 - apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: ipaas:admins
+    labels:
+      app: redhat-ipaas
+roleRef:
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: ipaas-deployer
+  namespace: ipaas-staging
+- kind: ServiceAccount
+  name: jenkins
+  namespace: ipaas-ci
+- kind: Group
+  name: dedicated-admins
+userNames:
+- system:serviceaccount:ipaas-staging:ipaas-deployer
+- system:serviceaccount:ipaas-ci:jenkins
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:


### PR DESCRIPTION
Jenkins needs admin access, so that it can tag images, rollout deployments and so on.