### PR TITLE
Fix token-rp ImageStream version

### DIFF
--- a/redhat-ipaas-single-tenant.yml
+++ b/redhat-ipaas-single-tenant.yml
@@ -155,7 +155,7 @@ objects:
         name: docker.io/rhipaas/token-rp:v0.4.0
       importPolicy:
         scheduled: true
-      name: v0.2.0
+      name: v0.4.0
 - apiVersion: v1
   kind: Secret
   metadata:

--- a/redhat-ipaas.yml
+++ b/redhat-ipaas.yml
@@ -155,7 +155,7 @@ objects:
         name: docker.io/rhipaas/token-rp:v0.4.0
       importPolicy:
         scheduled: true
-      name: v0.2.0
+      name: v0.4.0
 - apiVersion: v1
   kind: Secret
   metadata:


### PR DESCRIPTION
This fixes version of IS as later [in template](https://github.com/redhat-ipaas/openshift-templates/blob/master/redhat-ipaas.yml#L544) `v0.4.0` is used. 

Maybe name could left blank/changed to `latest` and keep upgrading just `DockerImage` part of `ImageStream`. @jimmidyson wdyt?