### PR TITLE
chore(token-rp): Bump token-rp to v0.6.0

### DIFF
--- a/generator/02-syndesis-image-streams.yml.mustache
+++ b/generator/02-syndesis-image-streams.yml.mustache
@@ -55,10 +55,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.5.0
+        name: docker.io/syndesis/token-rp:v0.6.0
       importPolicy:
         scheduled: true
-      name: v0.5.0
+      name: v0.6.0
 - apiVersion: v1
   kind: ImageStream
   metadata:

--- a/generator/03-syndesis-git-proxy.yml.mustache
+++ b/generator/03-syndesis-git-proxy.yml.mustache
@@ -48,7 +48,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: syndesis/token-rp:v0.5.0
+          image: syndesis/token-rp:v0.6.0
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           args:
@@ -83,7 +83,7 @@
         - syndesis-github-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-openshift-proxy.yml.mustache
+++ b/generator/03-syndesis-openshift-proxy.yml.mustache
@@ -48,7 +48,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: syndesis/token-rp:v0.5.0
+          image: syndesis/token-rp:v0.6.0
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           args:
@@ -83,7 +83,7 @@
         - syndesis-openshift-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -461,7 +461,7 @@ objects:
       spec:
         containers:
         - name: syndesis-github-proxy
-          image: syndesis/token-rp:v0.5.0
+          image: syndesis/token-rp:v0.6.0
 
           imagePullPolicy: IfNotPresent
           args:
@@ -1750,7 +1750,7 @@ objects:
       spec:
         containers:
         - name: syndesis-openshift-proxy
-          image: syndesis/token-rp:v0.5.0
+          image: syndesis/token-rp:v0.6.0
 
           imagePullPolicy: IfNotPresent
           args:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -461,7 +461,7 @@ objects:
       spec:
         containers:
         - name: syndesis-github-proxy
-          image: syndesis/token-rp:v0.5.0
+          image: syndesis/token-rp:v0.6.0
 
           imagePullPolicy: IfNotPresent
           args:
@@ -1750,7 +1750,7 @@ objects:
       spec:
         containers:
         - name: syndesis-openshift-proxy
-          image: syndesis/token-rp:v0.5.0
+          image: syndesis/token-rp:v0.6.0
 
           imagePullPolicy: IfNotPresent
           args:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -178,10 +178,10 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.5.0
+        name: docker.io/syndesis/token-rp:v0.6.0
       importPolicy:
         scheduled: true
-      name: v0.5.0
+      name: v0.6.0
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -573,7 +573,7 @@ objects:
         - syndesis-github-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 
     - type: ConfigChange
@@ -1878,7 +1878,7 @@ objects:
         - syndesis-openshift-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 
     - type: ConfigChange

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -178,10 +178,10 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.5.0
+        name: docker.io/syndesis/token-rp:v0.6.0
       importPolicy:
         scheduled: true
-      name: v0.5.0
+      name: v0.6.0
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -593,7 +593,7 @@ objects:
         - syndesis-github-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 
     - type: ConfigChange
@@ -1898,7 +1898,7 @@ objects:
         - syndesis-openshift-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 
     - type: ConfigChange

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -178,10 +178,10 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.5.0
+        name: docker.io/syndesis/token-rp:v0.6.0
       importPolicy:
         scheduled: true
-      name: v0.5.0
+      name: v0.6.0
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -593,7 +593,7 @@ objects:
         - syndesis-github-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 
     - type: ConfigChange
@@ -1898,7 +1898,7 @@ objects:
         - syndesis-openshift-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.5.0
+          name: syndesis-token-rp:v0.6.0
       type: ImageChange
 
     - type: ConfigChange


### PR DESCRIPTION
This includes latest version of token-rp that should retry retrieval of provider config on startup to prevent continual crash loop if keycloak isn't up already.