### PR TITLE
Fix keycloak readiness check

### DIFF
--- a/generator/03-syndesis-keycloak.yml.mustache
+++ b/generator/03-syndesis-keycloak.yml.mustache
@@ -173,7 +173,7 @@
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              path: "/auth"
+              path: "/auth/"
               port: 8080
             initialDelaySeconds: 15
           ports:
@@ -1224,4 +1224,3 @@
         "resetCredentialsFlow": "reset credentials",
         "clientAuthenticationFlow": "clients"
       }
-

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -659,7 +659,7 @@ objects:
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              path: "/auth"
+              path: "/auth/"
               port: 8080
             initialDelaySeconds: 15
           ports:
@@ -1698,7 +1698,6 @@ objects:
         "resetCredentialsFlow": "reset credentials",
         "clientAuthenticationFlow": "clients"
       }
-
 - apiVersion: v1
   kind: Service
   metadata:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -663,7 +663,7 @@ objects:
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              path: "/auth"
+              path: "/auth/"
               port: 8080
             initialDelaySeconds: 15
           ports:
@@ -1702,7 +1702,6 @@ objects:
         "resetCredentialsFlow": "reset credentials",
         "clientAuthenticationFlow": "clients"
       }
-
 - apiVersion: v1
   kind: Service
   metadata:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -745,7 +745,7 @@ objects:
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              path: "/auth"
+              path: "/auth/"
               port: 8080
             initialDelaySeconds: 15
           ports:
@@ -1792,7 +1792,6 @@ objects:
         "resetCredentialsFlow": "reset credentials",
         "clientAuthenticationFlow": "clients"
       }
-
 - apiVersion: v1
   kind: Service
   metadata:

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -765,7 +765,7 @@ objects:
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              path: "/auth"
+              path: "/auth/"
               port: 8080
             initialDelaySeconds: 15
           ports:
@@ -1812,7 +1812,6 @@ objects:
         "resetCredentialsFlow": "reset credentials",
         "clientAuthenticationFlow": "clients"
       }
-
 - apiVersion: v1
   kind: Service
   metadata:

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -769,7 +769,7 @@ objects:
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:
-              path: "/auth"
+              path: "/auth/"
               port: 8080
             initialDelaySeconds: 15
           ports:
@@ -1816,7 +1816,6 @@ objects:
         "resetCredentialsFlow": "reset credentials",
         "clientAuthenticationFlow": "clients"
       }
-
 - apiVersion: v1
   kind: Service
   metadata:


### PR DESCRIPTION
Actually, "/auth" redirected to "/auth/" which causes the healthcheck to fail.