### PR TITLE
Add timeout for health checks and externalized config for syndesis-verifier

### DIFF
--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -135,11 +135,19 @@
           image: syndesis/syndesis-rest:latest
 {{/Dev}}
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: "/health"
               port: 8181
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -147,6 +155,7 @@
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -91,15 +91,17 @@
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 10
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 180
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -117,12 +119,19 @@
             requests:
               cpu: 200m
               memory: 612Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
         volumes:
         - name: syndesis-verifier-tls
           emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: syndesis-verifier-config
     triggers:
 {{^Dev}}
     - imageChangeParams:
@@ -135,3 +144,25 @@
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-verifier
+    name: syndesis-verifier-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -1909,11 +1909,19 @@ objects:
           image: syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: "/health"
               port: 8181
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -1921,6 +1929,7 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
@@ -2219,15 +2228,17 @@ objects:
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 10
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 180
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2245,15 +2256,44 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
         volumes:
         - name: syndesis-verifier-tls
           emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: syndesis-verifier-config
     triggers:
 
     - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-verifier
+    name: syndesis-verifier-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
 
 
 - apiVersion: v1

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -1913,11 +1913,19 @@ objects:
           image: syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: "/health"
               port: 8181
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -1925,6 +1933,7 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
@@ -2223,15 +2232,17 @@ objects:
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 10
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 180
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2249,15 +2260,44 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
         volumes:
         - name: syndesis-verifier-tls
           emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: syndesis-verifier-config
     triggers:
 
     - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-verifier
+    name: syndesis-verifier-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
 - apiVersion: v1
   kind: OAuthClient
   metadata:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -2011,11 +2011,19 @@ objects:
           image: ' '
 
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: "/health"
               port: 8181
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2023,6 +2031,7 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
@@ -2337,15 +2346,17 @@ objects:
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 10
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 180
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2363,12 +2374,19 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
         volumes:
         - name: syndesis-verifier-tls
           emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: syndesis-verifier-config
     triggers:
     - imageChangeParams:
         automatic: true
@@ -2380,6 +2398,28 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-verifier
+    name: syndesis-verifier-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
 
 
 - apiVersion: v1

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -2031,11 +2031,19 @@ objects:
           image: ' '
 
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: "/health"
               port: 8181
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2043,6 +2051,7 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
@@ -2357,15 +2366,17 @@ objects:
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 10
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 180
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2383,12 +2394,19 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
         volumes:
         - name: syndesis-verifier-tls
           emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: syndesis-verifier-config
     triggers:
     - imageChangeParams:
         automatic: true
@@ -2400,6 +2418,28 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-verifier
+    name: syndesis-verifier-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
 
 
 - apiVersion: v1

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -2035,11 +2035,19 @@ objects:
           image: ' '
 
           imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 180
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: "/health"
               port: 8181
             initialDelaySeconds: 5
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2047,6 +2055,7 @@ objects:
             name: prometheus
           - containerPort: 8778
             name: jolokia
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
@@ -2361,15 +2370,17 @@ objects:
           readinessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 10
+            timeoutSeconds: 3
           livenessProbe:
             httpGet:
               path: /health
-              port: 8080
+              port: 8181
               scheme: HTTP
             initialDelaySeconds: 180
+            timeoutSeconds: 3
           ports:
           - containerPort: 8080
             name: http
@@ -2387,12 +2398,19 @@ objects:
             requests:
               cpu: 200m
               memory: 612Mi
+          # spring-boot automatically picks up application.yml from ./config
+          workingDir: /deployments
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          - name: config-volume
+            mountPath: /deployments/config
         volumes:
         - name: syndesis-verifier-tls
           emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: syndesis-verifier-config
     triggers:
     - imageChangeParams:
         automatic: true
@@ -2404,6 +2422,28 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
+
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-verifier
+    name: syndesis-verifier-config
+  data:
+    application.yml: |-
+      server:
+        port: 8080
+      # We only want the status, not the full data. Hence security on, sensitive off.
+      # See https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-monitoring.html
+      # For details
+      management:
+        port: 8181
+        security:
+          enabled: true
+      endpoints:
+        health:
+          sensitive: false
 - apiVersion: v1
   kind: OAuthClient
   metadata:


### PR DESCRIPTION
The timeout is set to 3s initially which should help in fixing issue in slow network situation (as we have on our staging openshift cluster).