### PR TITLE
chore(configuration): Use TLS for local development

### DIFF
--- a/generator/03-syndesis-datamapper.yml.mustache
+++ b/generator/03-syndesis-datamapper.yml.mustache
@@ -188,7 +188,7 @@
 {{^Dev}}
         allowedOrigins: https://${ROUTE_HOSTNAME}
 {{/Dev}}{{#Dev}}
-        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+        allowedOrigins: http://localhost:4200, https://localhost:4200, https://${ROUTE_HOSTNAME}
 {{/Dev}}
       spring:
         zipkin:

--- a/generator/03-syndesis-keycloak.yml.mustache
+++ b/generator/03-syndesis-keycloak.yml.mustache
@@ -863,7 +863,7 @@
           "enabled": true,
           "clientAuthenticatorType": "client-secret",
 {{#Dev}}
-          "redirectUris": [ "https://${ROUTE_HOSTNAME}/*", "http://localhost:4200/*"],
+          "redirectUris": [ "https://${ROUTE_HOSTNAME}/*", "http://localhost:4200/*", "https://localhost:4200/*"],
 {{/Dev}}{{^Dev}}
           "redirectUris": [ "https://${ROUTE_HOSTNAME}/*" ],
 {{/Dev}}

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -206,7 +206,7 @@
 {{^Dev}}
         allowedOrigins: https://${ROUTE_HOSTNAME}
 {{/Dev}}{{#Dev}}
-        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+        allowedOrigins: http://localhost:4200, https://localhost:4200, https://${ROUTE_HOSTNAME}
 {{/Dev}}
       cache:
         cluster:

--- a/support/serviceaccount-as-oauthclient-restricted.yml
+++ b/support/serviceaccount-as-oauthclient-restricted.yml
@@ -5,6 +5,6 @@ metadata:
   labels:
     app: syndesis
   annotations:
-    serviceaccounts.openshift.io/oauth-redirecturi.local: http://localhost:4200
+    serviceaccounts.openshift.io/oauth-redirecturi.local: https://localhost:4200
     serviceaccounts.openshift.io/oauth-redirecturi.route: https://
     serviceaccounts.openshift.io/oauth-redirectreference.route: '{"kind": "OAuthRedirectReference", "apiVersion": "v1", "reference": {"kind": "Route","name": "syndesis-ui"}}'

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -294,7 +294,7 @@ objects:
   data:
     application.yml: |-
       cors:
-        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+        allowedOrigins: http://localhost:4200, https://localhost:4200, https://${ROUTE_HOSTNAME}
 
       spring:
         zipkin:
@@ -1345,7 +1345,7 @@ objects:
           "surrogateAuthRequired": false,
           "enabled": true,
           "clientAuthenticatorType": "client-secret",
-          "redirectUris": [ "https://${ROUTE_HOSTNAME}/*", "http://localhost:4200/*"],
+          "redirectUris": [ "https://${ROUTE_HOSTNAME}/*", "http://localhost:4200/*", "https://localhost:4200/*"],
 
           "webOrigins": [ "+" ],
           "notBefore": 0,
@@ -1984,7 +1984,7 @@ objects:
             registration: property
             classes: io.syndesis.rest.v1.V1Application
       cors:
-        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+        allowedOrigins: http://localhost:4200, https://localhost:4200, https://${ROUTE_HOSTNAME}
 
       cache:
         cluster:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -298,7 +298,7 @@ objects:
   data:
     application.yml: |-
       cors:
-        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+        allowedOrigins: http://localhost:4200, https://localhost:4200, https://${ROUTE_HOSTNAME}
 
       spring:
         zipkin:
@@ -1349,7 +1349,7 @@ objects:
           "surrogateAuthRequired": false,
           "enabled": true,
           "clientAuthenticatorType": "client-secret",
-          "redirectUris": [ "https://${ROUTE_HOSTNAME}/*", "http://localhost:4200/*"],
+          "redirectUris": [ "https://${ROUTE_HOSTNAME}/*", "http://localhost:4200/*", "https://localhost:4200/*"],
 
           "webOrigins": [ "+" ],
           "notBefore": 0,
@@ -1988,7 +1988,7 @@ objects:
             registration: property
             classes: io.syndesis.rest.v1.V1Application
       cors:
-        allowedOrigins: http://localhost:4200, https://${ROUTE_HOSTNAME}
+        allowedOrigins: http://localhost:4200, https://localhost:4200, https://${ROUTE_HOSTNAME}
 
       cache:
         cluster:


### PR DESCRIPTION
Configures TLS (`https://localhost:4200`) endpoints in deployment
descriptors in addition to the existing non-TLS
(`http://localhost:4200`) endpoints for CORS and Keycloak configuration,
except for the OAuth client redirect URL configured in Service Account.