### PR TITLE
Added resource limits to deployment strategy

### DIFF
--- a/generator/03-syndesis-atlasmap.yml.mustache
+++ b/generator/03-syndesis-atlasmap.yml.mustache
@@ -64,6 +64,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/generator/03-syndesis-db.yml.mustache
+++ b/generator/03-syndesis-db.yml.mustache
@@ -48,6 +48,10 @@
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:

--- a/generator/03-syndesis-git-proxy.yml.mustache
+++ b/generator/03-syndesis-git-proxy.yml.mustache
@@ -35,6 +35,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/generator/03-syndesis-keycloak.yml.mustache
+++ b/generator/03-syndesis-keycloak.yml.mustache
@@ -105,6 +105,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/generator/03-syndesis-openshift-proxy.yml.mustache
+++ b/generator/03-syndesis-openshift-proxy.yml.mustache
@@ -35,6 +35,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -87,6 +87,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/generator/03-syndesis-ui.yml.mustache
+++ b/generator/03-syndesis-ui.yml.mustache
@@ -60,6 +60,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -33,6 +33,10 @@
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -284,6 +284,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -465,6 +469,10 @@ objects:
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:
@@ -557,6 +565,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -709,6 +721,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1854,6 +1870,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1988,6 +2008,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2228,6 +2252,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2328,6 +2356,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -190,6 +190,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -363,6 +367,10 @@ objects:
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:
@@ -455,6 +463,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -606,6 +618,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1752,6 +1768,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1885,6 +1905,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2117,6 +2141,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2218,6 +2246,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -194,6 +194,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -367,6 +371,10 @@ objects:
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:
@@ -459,6 +467,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -610,6 +622,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1756,6 +1772,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1889,6 +1909,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2121,6 +2145,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2222,6 +2250,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -280,6 +280,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -448,6 +452,10 @@ objects:
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:
@@ -533,6 +541,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -692,6 +704,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1846,6 +1862,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1987,6 +2007,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2227,6 +2251,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2336,6 +2364,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -280,6 +280,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -461,6 +465,10 @@ objects:
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:
@@ -553,6 +561,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -712,6 +724,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1866,6 +1882,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2007,6 +2027,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2247,6 +2271,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2356,6 +2384,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -284,6 +284,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -465,6 +469,10 @@ objects:
       component: syndesis-db
     strategy:
       type: Recreate
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
     template:
       metadata:
         labels:
@@ -557,6 +565,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -716,6 +728,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -1870,6 +1886,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2011,6 +2031,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2251,6 +2275,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:
@@ -2360,6 +2388,10 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 10800
         updatePeriodSeconds: 1
+      resources:
+        limits:
+          cpu: "100m"
+          memory: "256Mi"
       type: Rolling
     template:
       metadata:


### PR DESCRIPTION
So that the deployer pods are limited to 256mi (instead of 512mi default).
Interestingly on OSO its not possible to have a limit less than 256mi,
otherwise the deployment stuck as 'New' and do not proceed
(even not after an hour).

As bonus 'syndesis-datamapper' file has been renamed to 'syndesis-atlasamap'.