### PR TITLE
feat(limits): Add and adjust memory limits for Minishift and OSO Pro

### DIFF
--- a/generator/03-syndesis-atlasmap.yml.mustache
+++ b/generator/03-syndesis-atlasmap.yml.mustache
@@ -66,8 +66,9 @@
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -90,7 +91,15 @@
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -109,6 +118,11 @@
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -159,7 +173,7 @@
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}

--- a/generator/03-syndesis-db.yml.mustache
+++ b/generator/03-syndesis-db.yml.mustache
@@ -50,8 +50,9 @@
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -85,6 +86,8 @@
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}

--- a/generator/03-syndesis-keycloak.yml.mustache
+++ b/generator/03-syndesis-keycloak.yml.mustache
@@ -107,8 +107,9 @@
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -131,7 +132,15 @@
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -150,6 +159,11 @@
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -186,13 +200,12 @@
               path: "/auth/"
               port: 8080
             initialDelaySeconds: 10{{/Probeless}}
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:

--- a/generator/03-syndesis-openshift-proxy.yml.mustache
+++ b/generator/03-syndesis-openshift-proxy.yml.mustache
@@ -37,8 +37,9 @@
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -80,13 +81,18 @@
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -89,8 +89,9 @@
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -113,7 +114,15 @@
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -132,6 +141,11 @@
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -182,13 +196,15 @@
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -207,7 +223,6 @@
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap

--- a/generator/03-syndesis-ui.yml.mustache
+++ b/generator/03-syndesis-ui.yml.mustache
@@ -62,8 +62,9 @@
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -97,13 +98,13 @@
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -35,8 +35,9 @@
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -59,7 +60,15 @@
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -78,6 +87,11 @@
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -121,7 +135,7 @@
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -286,8 +286,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -310,7 +311,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -329,6 +338,11 @@ objects:
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -376,7 +390,7 @@ objects:
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}
@@ -471,8 +485,9 @@ objects:
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -506,6 +521,8 @@ objects:
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}
@@ -639,8 +656,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -663,7 +681,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -682,6 +708,11 @@ objects:
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -705,13 +736,12 @@ objects:
           name: syndesis-keycloak
           imagePullPolicy: IfNotPresent
 
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -1795,8 +1825,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1827,13 +1858,18 @@ objects:
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls
@@ -1940,8 +1976,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1964,7 +2001,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -1983,6 +2028,11 @@ objects:
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -2030,13 +2080,15 @@ objects:
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -2054,7 +2106,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap
@@ -2182,8 +2233,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2204,13 +2256,13 @@ objects:
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:
@@ -2293,8 +2345,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2317,7 +2370,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -2336,6 +2397,11 @@ objects:
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -2364,7 +2430,7 @@ objects:
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -192,8 +192,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -216,7 +217,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -235,6 +244,11 @@ objects:
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -282,7 +296,7 @@ objects:
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}
@@ -369,8 +383,9 @@ objects:
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -404,6 +419,8 @@ objects:
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}
@@ -537,8 +554,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -561,7 +579,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -580,6 +606,11 @@ objects:
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -612,13 +643,12 @@ objects:
               path: "/auth/"
               port: 8080
             initialDelaySeconds: 10
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -1694,8 +1724,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1733,13 +1764,18 @@ objects:
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls
@@ -1838,8 +1874,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1862,7 +1899,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -1881,6 +1926,11 @@ objects:
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -1928,13 +1978,15 @@ objects:
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -1944,7 +1996,6 @@ objects:
     triggers:
 
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap
@@ -2072,8 +2123,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2103,13 +2155,13 @@ objects:
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:
@@ -2184,8 +2236,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2208,7 +2261,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -2227,6 +2288,11 @@ objects:
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -2266,7 +2332,7 @@ objects:
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -196,8 +196,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -220,7 +221,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -239,6 +248,11 @@ objects:
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -286,7 +300,7 @@ objects:
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}
@@ -373,8 +387,9 @@ objects:
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -408,6 +423,8 @@ objects:
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}
@@ -541,8 +558,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -565,7 +583,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -584,6 +610,11 @@ objects:
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -616,13 +647,12 @@ objects:
               path: "/auth/"
               port: 8080
             initialDelaySeconds: 10
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -1698,8 +1728,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1737,13 +1768,18 @@ objects:
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls
@@ -1842,8 +1878,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1866,7 +1903,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -1885,6 +1930,11 @@ objects:
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -1932,13 +1982,15 @@ objects:
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -1948,7 +2000,6 @@ objects:
     triggers:
 
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap
@@ -2076,8 +2127,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2107,13 +2159,13 @@ objects:
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:
@@ -2188,8 +2240,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2212,7 +2265,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -2231,6 +2292,11 @@ objects:
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -2270,7 +2336,7 @@ objects:
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -282,8 +282,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -306,7 +307,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -325,6 +334,11 @@ objects:
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -372,7 +386,7 @@ objects:
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}
@@ -454,8 +468,9 @@ objects:
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -489,6 +504,8 @@ objects:
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}
@@ -615,8 +632,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -639,7 +657,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -658,6 +684,11 @@ objects:
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -690,13 +721,12 @@ objects:
               path: "/auth/"
               port: 8080
             initialDelaySeconds: 10
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -1780,8 +1810,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1819,13 +1850,18 @@ objects:
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls
@@ -1932,8 +1968,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1956,7 +1993,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -1975,6 +2020,11 @@ objects:
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -2022,13 +2072,15 @@ objects:
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -2046,7 +2098,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap
@@ -2174,8 +2225,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2205,13 +2257,13 @@ objects:
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:
@@ -2294,8 +2346,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2318,7 +2371,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -2337,6 +2398,11 @@ objects:
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -2376,7 +2442,7 @@ objects:
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -282,8 +282,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -306,7 +307,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -325,6 +334,11 @@ objects:
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -372,7 +386,7 @@ objects:
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}
@@ -467,8 +481,9 @@ objects:
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -502,6 +517,8 @@ objects:
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}
@@ -635,8 +652,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -659,7 +677,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -678,6 +704,11 @@ objects:
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -710,13 +741,12 @@ objects:
               path: "/auth/"
               port: 8080
             initialDelaySeconds: 10
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -1800,8 +1830,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1839,13 +1870,18 @@ objects:
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls
@@ -1952,8 +1988,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1976,7 +2013,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -1995,6 +2040,11 @@ objects:
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -2042,13 +2092,15 @@ objects:
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -2066,7 +2118,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap
@@ -2194,8 +2245,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2225,13 +2277,13 @@ objects:
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:
@@ -2314,8 +2366,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2338,7 +2391,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -2357,6 +2418,11 @@ objects:
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -2396,7 +2462,7 @@ objects:
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -286,8 +286,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -310,7 +311,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-atlasmap-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -329,6 +338,11 @@ objects:
           volumeMounts:
           - name: syndesis-atlasmap-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-atlasmap
         containers:
         - name: atlasmap
@@ -376,7 +390,7 @@ objects:
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
           emptyDir: {}
@@ -471,8 +485,9 @@ objects:
       type: Recreate
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
     template:
       metadata:
         labels:
@@ -506,6 +521,8 @@ objects:
               - -c
               - psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'
             initialDelaySeconds: 5
+          # DB QoS class is "Guaranteed" (requests == limits)
+          # Note: On OSO there is no Guaranteed class, its always burstable
           resources:
             limits:
               memory: ${POSTGRESQL_MEMORY_LIMIT}
@@ -639,8 +656,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -663,7 +681,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-keycloak-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -682,6 +708,11 @@ objects:
           volumeMounts:
           - name: syndesis-keycloak-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         containers:
         - args:
           - -b
@@ -714,13 +745,12 @@ objects:
               path: "/auth/"
               port: 8080
             initialDelaySeconds: 10
+          # (on OSO relation requests to limits is fixed)
           resources:
             limits:
-              cpu: 2000m
               memory: 768Mi
             requests:
-              cpu: 200m
-              memory: 768Mi
+              memory: 480Mi
           ports:
           - containerPort: 8080
           volumeMounts:
@@ -1804,8 +1834,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1843,13 +1874,18 @@ objects:
           volumeMounts:
           - mountPath: /tls
             name: tls-volume
+          # QoS class "Burstable", as the we actually (a) dont expect the 
+          # the contaner to eat up that much of memory and (b) not essential
+          # for the core functionality (but only for openshift related operations for
+          # running integrations)
+          # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 2000m
+              cpu: 1000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 40Mi
         volumes:
         - secret:
             secretName: syndesis-openshift-proxy-tls
@@ -1956,8 +1992,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -1980,7 +2017,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-rest-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -1999,6 +2044,11 @@ objects:
           volumeMounts:
           - name: syndesis-rest-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-rest
@@ -2046,13 +2096,15 @@ objects:
             mountPath: /tls-keystore
           - name: config-volume
             mountPath: /deployments/config
+          # Set QoS class to "Guaranteed" (limits == requests)
+          # This doesn't work on OSO as there is a fixed ratio 
+          # from limit to resource (80% currently). 'requests' is ignored there
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
               cpu: 200m
-              memory: 612Mi
+              memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
           emptyDir: {}
@@ -2070,7 +2122,6 @@ objects:
       type: ImageChange
 
     - type: ConfigChange
-
 
 - apiVersion: v1
   kind: ConfigMap
@@ -2198,8 +2249,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2229,13 +2281,13 @@ objects:
           - mountPath: /usr/share/nginx/html/config.json
             name: config-volume
             subPath: config/config.json
+          # Set to burstable with a low memory footprint to start (50 Mi)
           resources:
             limits:
-              cpu: 2000m
               memory: 255Mi
             requests:
               cpu: 200m
-              memory: 255Mi
+              memory: 50Mi
         volumes:
         - configMap:
             items:
@@ -2318,8 +2370,9 @@ objects:
         updatePeriodSeconds: 1
       resources:
         limits:
-          cpu: "100m"
           memory: "256Mi"
+        requests:
+          memory: "20Mi"
       type: Rolling
     template:
       metadata:
@@ -2342,7 +2395,15 @@ objects:
               "volumeMounts": [{
                 "name": "syndesis-verifier-tls",
                 "mountPath": "/tls-keystore"
-              }]
+              }],
+              "resources": {
+                "limits": {
+                  "memory": "255Mi"
+                },
+                "requests": { 
+                  "memory": "20Mi"
+                }
+              }
             }]
       spec:
         initContainers:
@@ -2361,6 +2422,11 @@ objects:
           volumeMounts:
           - name: syndesis-verifier-tls
             mountPath: /tls-keystore
+          resources:
+            limits:
+              memory: 255Mi
+            requests:
+              memory: 20Mi
         serviceAccountName: syndesis-rest
         containers:
         - name: syndesis-verifier
@@ -2400,7 +2466,7 @@ objects:
               memory: 512Mi
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments
           volumeMounts:


### PR DESCRIPTION
The memory limits has been adjusted so that the templates also run on
OpenShift Online Pro which currently dictate a minimum memory limit of 255Mi.
(although db, openshift-proxy and ui can be run with far less).