### PR TITLE
refactor(limits): Remove CPU limits for now

### DIFF
--- a/generator/03-syndesis-atlasmap.yml.mustache
+++ b/generator/03-syndesis-atlasmap.yml.mustache
@@ -169,10 +169,8 @@
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls

--- a/generator/03-syndesis-openshift-proxy.yml.mustache
+++ b/generator/03-syndesis-openshift-proxy.yml.mustache
@@ -88,10 +88,8 @@
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -203,7 +203,6 @@
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls

--- a/generator/03-syndesis-ui.yml.mustache
+++ b/generator/03-syndesis-ui.yml.mustache
@@ -103,7 +103,6 @@
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -131,10 +131,8 @@
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -386,10 +386,8 @@ objects:
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
@@ -1865,10 +1863,8 @@ objects:
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:
@@ -2087,7 +2083,6 @@ objects:
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
@@ -2261,7 +2256,6 @@ objects:
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:
@@ -2426,10 +2420,8 @@ objects:
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -292,10 +292,8 @@ objects:
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
@@ -1771,10 +1769,8 @@ objects:
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:
@@ -1985,7 +1981,6 @@ objects:
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
@@ -2160,7 +2155,6 @@ objects:
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:
@@ -2328,10 +2322,8 @@ objects:
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -296,10 +296,8 @@ objects:
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
@@ -1775,10 +1773,8 @@ objects:
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:
@@ -1989,7 +1985,6 @@ objects:
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
@@ -2164,7 +2159,6 @@ objects:
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:
@@ -2332,10 +2326,8 @@ objects:
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -382,10 +382,8 @@ objects:
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
@@ -1857,10 +1855,8 @@ objects:
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:
@@ -2079,7 +2075,6 @@ objects:
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
@@ -2262,7 +2257,6 @@ objects:
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:
@@ -2438,10 +2432,8 @@ objects:
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -382,10 +382,8 @@ objects:
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
@@ -1877,10 +1875,8 @@ objects:
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:
@@ -2099,7 +2095,6 @@ objects:
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
@@ -2282,7 +2277,6 @@ objects:
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:
@@ -2458,10 +2452,8 @@ objects:
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -386,10 +386,8 @@ objects:
             mountPath: /deployments/config
           resources:
             limits:
-              cpu: 2000m
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 255Mi
         volumes:
         - name: syndesis-atlasmap-tls
@@ -1881,10 +1879,8 @@ objects:
           # Note: Does not work on OSO (theres a fixed ration between limits / requests)
           resources:
             limits:
-              cpu: 1000m
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 40Mi
         volumes:
         - secret:
@@ -2103,7 +2099,6 @@ objects:
             limits:
               memory: 612Mi
             requests:
-              cpu: 200m
               memory: 256Mi
         volumes:
         - name: syndesis-rest-tls
@@ -2286,7 +2281,6 @@ objects:
             limits:
               memory: 255Mi
             requests:
-              cpu: 200m
               memory: 50Mi
         volumes:
         - configMap:
@@ -2462,10 +2456,8 @@ objects:
             protocol: TCP
           resources:
             limits:
-              cpu: 2000m
               memory: 512Mi
             requests:
-              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments


### PR DESCRIPTION
First, it's not really clear how they should look like.
Then it seems, that too high `limits` affect the way how pods can be scheduled
on the staging env.

We shoud introduce them if we need them.