### PR TITLE
Add syndesis-db pqsql service account

### DIFF
--- a/generator/03-syndesis-db.yml.mustache
+++ b/generator/03-syndesis-db.yml.mustache
@@ -35,6 +35,13 @@
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
 {{/Ephemeral}}    
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -59,6 +66,7 @@
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -470,6 +470,13 @@ objects:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
     
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -494,6 +501,7 @@ objects:
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:
@@ -2426,8 +2434,10 @@ objects:
             protocol: TCP
           resources:
             limits:
+              cpu: 2000m
               memory: 512Mi
             requests:
+              cpu: 200m
               memory: 280Mi
           # spring-boot automatically picks up application.yml from ./config
           workingDir: /deployments

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -368,6 +368,13 @@ objects:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
     
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -392,6 +399,7 @@ objects:
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -372,6 +372,13 @@ objects:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
     
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -396,6 +403,7 @@ objects:
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -453,6 +453,13 @@ objects:
     loadBalancer: {}
     
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -477,6 +484,7 @@ objects:
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -466,6 +466,13 @@ objects:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
     
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -490,6 +497,7 @@ objects:
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -470,6 +470,13 @@ objects:
         storage: ${POSTGRESQL_VOLUME_CAPACITY}
     
 - apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-db
+    name: syndesis-db
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     name: syndesis-db
@@ -494,6 +501,7 @@ objects:
           app: syndesis
           component: syndesis-db
       spec:
+        serviceAccountName: syndesis-db
         containers:
         - capabilities: {}
           env:


### PR DESCRIPTION
In case of using OpenShift storage on NFS, it's better to have a separate account for pqsql db storage to give correct rights, i.e. `oc add policy add-scc-to-user anyuid -z syndesys-db`