### PR TITLE
refactor(deployment): Changed from "Rolling" to "Recreate" strategy

### DIFF
--- a/generator/03-syndesis-atlasmap.yml.mustache
+++ b/generator/03-syndesis-atlasmap.yml.mustache
@@ -58,18 +58,12 @@
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/generator/03-syndesis-keycloak.yml.mustache
+++ b/generator/03-syndesis-keycloak.yml.mustache
@@ -99,18 +99,12 @@
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -81,18 +81,12 @@
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -27,18 +27,12 @@
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -280,18 +280,12 @@ objects:
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -650,18 +644,12 @@ objects:
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -1970,18 +1958,12 @@ objects:
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -2339,18 +2321,12 @@ objects:
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -186,18 +186,12 @@ objects:
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -548,18 +542,12 @@ objects:
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -1868,18 +1856,12 @@ objects:
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -2230,18 +2212,12 @@ objects:
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -190,18 +190,12 @@ objects:
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -552,18 +546,12 @@ objects:
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -1872,18 +1860,12 @@ objects:
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -2234,18 +2216,12 @@ objects:
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -276,18 +276,12 @@ objects:
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -626,18 +620,12 @@ objects:
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -1962,18 +1950,12 @@ objects:
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -2340,18 +2322,12 @@ objects:
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -276,18 +276,12 @@ objects:
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -646,18 +640,12 @@ objects:
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -1982,18 +1970,12 @@ objects:
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -2360,18 +2342,12 @@ objects:
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -280,18 +280,12 @@ objects:
       component: syndesis-atlasmap
       deploymentconfig: syndesis-atlasmap
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -650,18 +644,12 @@ objects:
       component: syndesis-keycloak
       deploymentconfig: syndesis-keycloak
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -1986,18 +1974,12 @@ objects:
       component: syndesis-rest
       deploymentconfig: syndesis-rest
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:
@@ -2364,18 +2346,12 @@ objects:
       component: syndesis-verifier
       deploymentconfig: syndesis-verifier
     strategy:
-      rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 10800
-        updatePeriodSeconds: 1
       resources:
         limits:
           memory: "256Mi"
         requests:
           memory: "20Mi"
-      type: Rolling
+      type: Recreate
     template:
       metadata:
         labels:


### PR DESCRIPTION
The issue with a 'Rolling' update is, that for some time it needs two containers running in parallel.
However, for resource restricted setup likes on OpenShift Online this very likely causes to go over the limits (of 4 GB).

Therefor changed back to a recreate strategy to avoid this extra memory costs.