### PR TITLE
feature(templates): Parameterise "Tag" and "Registry" in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Once all pods are started up, you should be able to access the Syndesis at `http
 | **OPENSHIFT_OAUTH_CLIENT_ID** | OpenShift OAuth client ID | syndesis |
 | **OPENSHIFT_OAUTH_CLIENT_SECRET** | OpenShift OAuth client secret | _(generated)_ |
 | **OPENSHIFT_OAUTH_DEFAULT_SCOPES** | OpenShift OAuth default scopes | user:full |
-| **PEMTOKEYSTORE_IMAGE** | PEM to keystore init container image | jimmidyson/pemtokeystore:v0.2.0 |
 | **GITHUB_OAUTH_DEFAULT_SCOPES** | GitHub OAuth default scopes | user:email public_repo |
 | **POSTGRESQL_MEMORY_LIMIT** | Maximum amount of memory the PostgreSQL container can use | 512Mi |
 | **POSTGRESQL_IMAGE_STREAM_NAMESPACE** | The OpenShift Namespace where the PostgreSQL ImageStream resides | openshift |
@@ -79,6 +78,10 @@ Once all pods are started up, you should be able to access the Syndesis at `http
 | **INSECURE_SKIP_VERIFY** | Whether to skip the verification of SSL certificates for internal services | false |
 | **TEST_SUPPORT_ENABLED** | Whether test support for e2e test is enabled | false |
 | **DEMO_DATA_ENABLED** | Whether demo data is automatically imported on startup | true |
+| **SYNDESIS_REGISTRY** | Registry from where to fetch Syndesis images | docker.io |
+| **CONTROLLERS_INTEGRATION_ENABLED**  | Should deployment of integrations be enabled? | true |
+| **ACCESS_TOKEN_LIFESPAN** | How many seconds should an access token be valid? | 300 |
+| **SESSION_LIFESPAN** | How long are idle SSO Sesions allow to exist (in ms) ? | 36000 |
 
 ## Running as a Cluster Admin
 

--- a/generator/01-header.yml.mustache
+++ b/generator/01-header.yml.mustache
@@ -68,7 +68,7 @@ parameters:
   required: true{{/Restricted}}
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: {{Registry}}/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes

--- a/generator/01-header.yml.mustache
+++ b/generator/01-header.yml.mustache
@@ -66,10 +66,6 @@ parameters:
   description: OpenShift OAuth default scopes
   value: "user:full"
   required: true{{/Restricted}}
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: {{Registry}}/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -116,6 +112,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED

--- a/generator/02-syndesis-image-streams.yml.mustache
+++ b/generator/02-syndesis-image-streams.yml.mustache
@@ -10,10 +10,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: {{Registry}}/syndesis/syndesis-rest:{{Tag}}
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{Tag}}
+      name: {{ Tags.Syndesis }}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -25,10 +25,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: {{Registry}}/jimmidyson/keycloak-openshift:2.5.4.Final
+        name: ${SYNDESIS_REGISTRY}/{{ Images.Keycloak }}
       importPolicy:
         scheduled: true
-      name: 2.5.4.Final
+      name: {{ Tags.Keycloak }}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -40,10 +40,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: {{Registry}}/syndesis/syndesis-ui:{{Tag}}
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{Tag}}
+      name: {{ Tags.Syndesis }}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -55,10 +55,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: {{Registry}}/syndesis/token-rp:v0.6.2
+        name: ${SYNDESIS_REGISTRY}/{{ Images.TokenRp }}
       importPolicy:
         scheduled: true
-      name: v0.6.2
+      name: {{ Tags.TokenRp }}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -70,10 +70,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: {{Registry}}/atlasmap/atlasmap:{{Tag}}
+        name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{Tag}}
+      name: {{ Tags.Syndesis }}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -85,8 +85,8 @@
     tags:
     - from:
         kind: DockerImage
-        name: {{Registry}}/syndesis/syndesis-verifier:{{Tag}}
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{Tag}}
+      name: {{ Tags.Syndesis }}
 {{/Dev}}

--- a/generator/02-syndesis-image-streams.yml.mustache
+++ b/generator/02-syndesis-image-streams.yml.mustache
@@ -10,10 +10,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-rest:latest
+        name: {{Registry}}/syndesis/syndesis-rest:{{Tag}}
       importPolicy:
         scheduled: true
-      name: latest
+      name: {{Tag}}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -25,7 +25,7 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/jimmidyson/keycloak-openshift:2.5.4.Final
+        name: {{Registry}}/jimmidyson/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
       name: 2.5.4.Final
@@ -40,10 +40,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-ui:latest
+        name: {{Registry}}/syndesis/syndesis-ui:{{Tag}}
       importPolicy:
         scheduled: true
-      name: latest
+      name: {{Tag}}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -55,7 +55,7 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.6.2
+        name: {{Registry}}/syndesis/token-rp:v0.6.2
       importPolicy:
         scheduled: true
       name: v0.6.2
@@ -70,10 +70,10 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/atlasmap/atlasmap:latest
+        name: {{Registry}}/atlasmap/atlasmap:{{Tag}}
       importPolicy:
         scheduled: true
-      name: latest
+      name: {{Tag}}
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -85,8 +85,8 @@
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-verifier:latest
+        name: {{Registry}}/syndesis/syndesis-verifier:{{Tag}}
       importPolicy:
         scheduled: true
-      name: latest
+      name: {{Tag}}
 {{/Dev}}

--- a/generator/03-syndesis-atlasmap.yml.mustache
+++ b/generator/03-syndesis-atlasmap.yml.mustache
@@ -142,7 +142,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: atlasmap/atlasmap:latest
+          image: {{Registry}}/atlasmap/atlasmap:{{Tag}}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -189,7 +189,7 @@
         - atlasmap
         from:
           kind: ImageStreamTag
-          name: syndesis-atlasmap:latest
+          name: syndesis-atlasmap:{{Tag}}
       type: ImageChange
 {{/Dev}}
 

--- a/generator/03-syndesis-atlasmap.yml.mustache
+++ b/generator/03-syndesis-atlasmap.yml.mustache
@@ -80,7 +80,7 @@
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "{{ Images.PemToKeystore }}",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -104,7 +104,7 @@
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: {{ Images.PemToKeystore }}
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -142,7 +142,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: {{Registry}}/atlasmap/atlasmap:{{Tag}}
+          image: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:{{ Tags.Syndesis }}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -189,7 +189,7 @@
         - atlasmap
         from:
           kind: ImageStreamTag
-          name: syndesis-atlasmap:{{Tag}}
+          name: syndesis-atlasmap:{{ Tags.Syndesis }}
       type: ImageChange
 {{/Dev}}
 

--- a/generator/03-syndesis-db.yml.mustache
+++ b/generator/03-syndesis-db.yml.mustache
@@ -109,7 +109,7 @@
         - postgresql
         from:
           kind: ImageStreamTag
-          name: postgresql:9.5
+          name: {{ Images.Postgresql }}
           namespace: ${POSTGRESQL_IMAGE_STREAM_NAMESPACE}
       type: ImageChange
     - type: ConfigChange

--- a/generator/03-syndesis-keycloak.yml.mustache
+++ b/generator/03-syndesis-keycloak.yml.mustache
@@ -121,7 +121,7 @@
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "{{ Images.PemToKeystore }}",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -145,7 +145,7 @@
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: {{ Images.PemToKeystore }}
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -185,7 +185,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: jimmidyson/keycloak-openshift:2.5.4.Final
+          image: {{ Images.Keycloak }}
 {{/Dev}}
           name: syndesis-keycloak
           imagePullPolicy: IfNotPresent
@@ -236,7 +236,7 @@
         - syndesis-keycloak
         from:
           kind: ImageStreamTag
-          name: syndesis-keycloak:2.5.4.Final
+          name: syndesis-keycloak:{{ Tags.Keycloak }}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-openshift-proxy.yml.mustache
+++ b/generator/03-syndesis-openshift-proxy.yml.mustache
@@ -53,7 +53,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: syndesis/token-rp:v0.6.2
+          image: {{ Images.TokenRp }}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           args:
@@ -105,7 +105,7 @@
         - syndesis-openshift-proxy
         from:
           kind: ImageStreamTag
-          name: syndesis-token-rp:v0.6.2
+          name: syndesis-token-rp:{{ Tags.TokenRp }}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -103,7 +103,7 @@
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "{{ Images.PemToKeystore }}",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -127,7 +127,7 @@
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: {{ Images.PemToKeystore }}
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -169,7 +169,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: {{Registry}}/syndesis/syndesis-rest:{{Tag}}
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:{{ Tags.Syndesis }}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -219,7 +219,7 @@
         - syndesis-rest
         from:
           kind: ImageStreamTag
-          name: syndesis-rest:{{Tag}}
+          name: syndesis-rest:{{ Tags.Syndesis }}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-rest.yml.mustache
+++ b/generator/03-syndesis-rest.yml.mustache
@@ -169,7 +169,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: syndesis/syndesis-rest:latest
+          image: {{Registry}}/syndesis/syndesis-rest:{{Tag}}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -219,7 +219,7 @@
         - syndesis-rest
         from:
           kind: ImageStreamTag
-          name: syndesis-rest:latest
+          name: syndesis-rest:{{Tag}}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-ui.yml.mustache
+++ b/generator/03-syndesis-ui.yml.mustache
@@ -78,7 +78,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: syndesis/syndesis-ui:latest
+          image: {{Registry}}/syndesis/syndesis-ui:{{Tag}}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
 {{^Probeless}}
@@ -120,7 +120,7 @@
         - syndesis-ui
         from:
           kind: ImageStreamTag
-          name: syndesis-ui:latest
+          name: syndesis-ui:{{Tag}}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-ui.yml.mustache
+++ b/generator/03-syndesis-ui.yml.mustache
@@ -78,7 +78,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: {{Registry}}/syndesis/syndesis-ui:{{Tag}}
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:{{ Tags.Syndesis }}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
 {{^Probeless}}
@@ -120,7 +120,7 @@
         - syndesis-ui
         from:
           kind: ImageStreamTag
-          name: syndesis-ui:{{Tag}}
+          name: syndesis-ui:{{ Tags.Syndesis }}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -49,7 +49,7 @@
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "{{ Images.PemToKeystore }}",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -73,7 +73,7 @@
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: {{ Images.PemToKeystore }}
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -103,7 +103,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: {{Registry}}/syndesis/syndesis-verifier:{{Tag}}
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:{{ Tags.Syndesis }}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
 {{^Probeless}}
@@ -157,7 +157,7 @@
         - syndesis-verifier
         from:
           kind: ImageStreamTag
-          name: syndesis-verifier:{{Tag}}
+          name: syndesis-verifier:{{ Tags.Syndesis }}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/03-syndesis-verifier.yml.mustache
+++ b/generator/03-syndesis-verifier.yml.mustache
@@ -103,7 +103,7 @@
 {{^Dev}}
           image: ' '
 {{/Dev}}{{#Dev}}
-          image: syndesis/syndesis-verifier:latest
+          image: {{Registry}}/syndesis/syndesis-verifier:{{Tag}}
 {{/Dev}}
           imagePullPolicy: IfNotPresent
 {{^Probeless}}
@@ -157,7 +157,7 @@
         - syndesis-verifier
         from:
           kind: ImageStreamTag
-          name: syndesis-verifier:latest
+          name: syndesis-verifier:{{Tag}}
       type: ImageChange
 {{/Dev}}
     - type: ConfigChange

--- a/generator/syndesis-template.go
+++ b/generator/syndesis-template.go
@@ -34,6 +34,19 @@ var installCommand = &cobra.Command{
 	Run:   install,
 }
 
+type images struct {
+	PemToKeystore string
+	TokenRp string
+	Keycloak string
+	Postgresql string
+}
+
+type tags struct {
+	Keycloak string
+	TokenRp string
+	Syndesis string
+}
+
 type Context struct {
 	Name       string
 	Dev        bool
@@ -42,9 +55,23 @@ type Context struct {
 	Probeless  bool
 	Tag        string
 	Registry   string
+	Images     images
+	Tags       tags
 }
 
-var context = Context{}
+// TODO: Could be added from a local configuration file
+var context = Context{
+	Images: images{
+	  PemToKeystore: "syndesis/pemtokeystore:v0.2.1",
+	  TokenRp: "syndesis/token-rp:v0.6.2",
+		Keycloak: "jimmidyson/keycloak-openshift:2.5.4.Final",
+		Postgresql: "postgresql:9.5",
+  },
+	Tags: tags{
+		Keycloak: "2.5.4.Final",
+		TokenRp: "v0.6.2",
+	},
+}
 
 func init() {
 	flags := installCommand.PersistentFlags()
@@ -53,7 +80,7 @@ func init() {
 	flags.BoolVar(&context.Restricted, "restricted", false, "Restricted mode?")
 	flags.BoolVar(&context.Ephemeral, "ephemeral", false, "Ephemeral mode?")
 	flags.BoolVar(&context.Probeless, "probeless", false, "Without probes")
-	flags.StringVar(&context.Tag,"tag", "latest", "Image tag to use")
+	flags.StringVar(&context.Tags.Syndesis,"tag", "latest", "Image tag to use")
 	flags.StringVar(&context.Registry,"registry", "docker.io", "Registry to use for imagestreams")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }

--- a/generator/syndesis-template.go
+++ b/generator/syndesis-template.go
@@ -40,16 +40,21 @@ type Context struct {
 	Ephemeral  bool
 	Restricted bool
 	Probeless  bool
+	Tag        string
+	Registry   string
 }
 
 var context = Context{}
 
 func init() {
-	installCommand.PersistentFlags().StringVar(&context.Name, "name", "syndesis", "Name of the template")
-	installCommand.PersistentFlags().BoolVar(&context.Dev, "dev", false, "Developer mode?")
-	installCommand.PersistentFlags().BoolVar(&context.Restricted, "restricted", false, "Restricted mode?")
-	installCommand.PersistentFlags().BoolVar(&context.Ephemeral, "ephemeral", false, "Ephemeral mode?")
-	installCommand.PersistentFlags().BoolVar(&context.Probeless, "probeless", false, "Without probes")
+	flags := installCommand.PersistentFlags()
+	flags.StringVar(&context.Name, "name", "syndesis", "Name of the template")
+	flags.BoolVar(&context.Dev, "dev", false, "Developer mode?")
+	flags.BoolVar(&context.Restricted, "restricted", false, "Restricted mode?")
+	flags.BoolVar(&context.Ephemeral, "ephemeral", false, "Ephemeral mode?")
+	flags.BoolVar(&context.Probeless, "probeless", false, "Without probes")
+	flags.StringVar(&context.Tag,"tag", "latest", "Image tag to use")
+	flags.StringVar(&context.Registry,"registry", "docker.io", "Registry to use for imagestreams")
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 }
 

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -62,10 +62,6 @@ parameters:
   description: OpenShift OAuth default scopes
   value: "user:full"
   required: true
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -112,6 +108,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED
@@ -140,7 +141,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-rest:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -155,7 +156,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/jimmidyson/keycloak-openshift:2.5.4.Final
+        name: ${SYNDESIS_REGISTRY}/jimmidyson/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
       name: 2.5.4.Final
@@ -170,7 +171,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-ui:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -185,7 +186,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.6.2
+        name: ${SYNDESIS_REGISTRY}/syndesis/token-rp:v0.6.2
       importPolicy:
         scheduled: true
       name: v0.6.2
@@ -200,7 +201,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/atlasmap/atlasmap:latest
+        name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -215,7 +216,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-verifier:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -302,7 +303,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -326,7 +327,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -672,7 +673,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -696,7 +697,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -1992,7 +1993,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2016,7 +2017,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2361,7 +2362,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2385,7 +2386,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -64,7 +64,7 @@ parameters:
   required: true
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -58,10 +58,6 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -108,6 +104,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED
@@ -208,7 +209,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -232,7 +233,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -267,7 +268,7 @@ objects:
             value: "true"
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: docker.io/atlasmap/atlasmap:latest
+          image: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -570,7 +571,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -594,7 +595,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -1890,7 +1891,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -1914,7 +1915,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -1953,7 +1954,7 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
-          image: docker.io/syndesis/syndesis-rest:latest
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2138,7 +2139,7 @@ objects:
       spec:
         containers:
         - name: syndesis-ui
-          image: docker.io/syndesis/syndesis-ui:latest
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2252,7 +2253,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2276,7 +2277,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2303,7 +2304,7 @@ objects:
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: docker.io/syndesis/syndesis-verifier:latest
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -60,7 +60,7 @@ parameters:
   required: true
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
@@ -267,7 +267,7 @@ objects:
             value: "true"
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: atlasmap/atlasmap:latest
+          image: docker.io/atlasmap/atlasmap:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -1953,7 +1953,7 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
-          image: syndesis/syndesis-rest:latest
+          image: docker.io/syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2138,7 +2138,7 @@ objects:
       spec:
         containers:
         - name: syndesis-ui
-          image: syndesis/syndesis-ui:latest
+          image: docker.io/syndesis/syndesis-ui:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2303,7 +2303,7 @@ objects:
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: syndesis/syndesis-verifier:latest
+          image: docker.io/syndesis/syndesis-verifier:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -62,10 +62,6 @@ parameters:
   description: OpenShift OAuth default scopes
   value: "user:full"
   required: true
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -112,6 +108,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED
@@ -212,7 +213,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -236,7 +237,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -271,7 +272,7 @@ objects:
             value: "true"
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: docker.io/atlasmap/atlasmap:latest
+          image: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -574,7 +575,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -598,7 +599,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -1894,7 +1895,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -1918,7 +1919,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -1957,7 +1958,7 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
-          image: docker.io/syndesis/syndesis-rest:latest
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2142,7 +2143,7 @@ objects:
       spec:
         containers:
         - name: syndesis-ui
-          image: docker.io/syndesis/syndesis-ui:latest
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2256,7 +2257,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2280,7 +2281,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2307,7 +2308,7 @@ objects:
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: docker.io/syndesis/syndesis-verifier:latest
+          image: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -64,7 +64,7 @@ parameters:
   required: true
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
@@ -271,7 +271,7 @@ objects:
             value: "true"
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: atlasmap/atlasmap:latest
+          image: docker.io/atlasmap/atlasmap:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:
@@ -1957,7 +1957,7 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
-          image: syndesis/syndesis-rest:latest
+          image: docker.io/syndesis/syndesis-rest:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2142,7 +2142,7 @@ objects:
       spec:
         containers:
         - name: syndesis-ui
-          image: syndesis/syndesis-ui:latest
+          image: docker.io/syndesis/syndesis-ui:latest
 
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -2307,7 +2307,7 @@ objects:
             value: /deployments
           - name: JAVA_OPTIONS
             value: "-Djava.net.preferIPv4Stack=true -Djavax.net.ssl.trustStore=/tls-keystore/openshift-truststore.jks -Duser.home=/tmp"
-          image: syndesis/syndesis-verifier:latest
+          image: docker.io/syndesis/syndesis-verifier:latest
 
           imagePullPolicy: IfNotPresent
           readinessProbe:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -58,10 +58,6 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -108,6 +104,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED
@@ -136,7 +137,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-rest:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -151,7 +152,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/jimmidyson/keycloak-openshift:2.5.4.Final
+        name: ${SYNDESIS_REGISTRY}/jimmidyson/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
       name: 2.5.4.Final
@@ -166,7 +167,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-ui:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -181,7 +182,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.6.2
+        name: ${SYNDESIS_REGISTRY}/syndesis/token-rp:v0.6.2
       importPolicy:
         scheduled: true
       name: v0.6.2
@@ -196,7 +197,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/atlasmap/atlasmap:latest
+        name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -211,7 +212,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-verifier:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -298,7 +299,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -322,7 +323,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -648,7 +649,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -672,7 +673,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -1984,7 +1985,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2008,7 +2009,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2362,7 +2363,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2386,7 +2387,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -60,7 +60,7 @@ parameters:
   required: true
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -58,10 +58,6 @@ parameters:
   generate: expression
   from: "[a-zA-Z0-9]{64}"
   required: true
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -108,6 +104,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED
@@ -136,7 +137,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-rest:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -151,7 +152,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/jimmidyson/keycloak-openshift:2.5.4.Final
+        name: ${SYNDESIS_REGISTRY}/jimmidyson/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
       name: 2.5.4.Final
@@ -166,7 +167,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-ui:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -181,7 +182,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.6.2
+        name: ${SYNDESIS_REGISTRY}/syndesis/token-rp:v0.6.2
       importPolicy:
         scheduled: true
       name: v0.6.2
@@ -196,7 +197,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/atlasmap/atlasmap:latest
+        name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -211,7 +212,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-verifier:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -298,7 +299,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -322,7 +323,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -668,7 +669,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -692,7 +693,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2004,7 +2005,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2028,7 +2029,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2382,7 +2383,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2406,7 +2407,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -60,7 +60,7 @@ parameters:
   required: true
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -62,10 +62,6 @@ parameters:
   description: OpenShift OAuth default scopes
   value: "user:full"
   required: true
-- name: PEMTOKEYSTORE_IMAGE
-  description: PEM to keystore init container image
-  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
-  required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes
   value: "user:email public_repo"
@@ -112,6 +108,11 @@ parameters:
   displayName: Insecure skip verify
   name: INSECURE_SKIP_VERIFY
   value: 'false'
+- description: Registry from where to fetch Syndesis images
+  displayName: Syndesis Image Registry
+  name: SYNDESIS_REGISTRY
+  required: true
+  value: 'docker.io'
 - description: Should deployment of integrations be enabled?
   displayName: Enable Integration Deployment
   name: CONTROLLERS_INTEGRATION_ENABLED
@@ -140,7 +141,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-rest:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -155,7 +156,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/jimmidyson/keycloak-openshift:2.5.4.Final
+        name: ${SYNDESIS_REGISTRY}/jimmidyson/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
       name: 2.5.4.Final
@@ -170,7 +171,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-ui:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -185,7 +186,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/token-rp:v0.6.2
+        name: ${SYNDESIS_REGISTRY}/syndesis/token-rp:v0.6.2
       importPolicy:
         scheduled: true
       name: v0.6.2
@@ -200,7 +201,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/atlasmap/atlasmap:latest
+        name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -215,7 +216,7 @@ objects:
     tags:
     - from:
         kind: DockerImage
-        name: docker.io/syndesis/syndesis-verifier:latest
+        name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
       name: latest
@@ -302,7 +303,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -326,7 +327,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -672,7 +673,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -696,7 +697,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2008,7 +2009,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2032,7 +2033,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore
@@ -2386,7 +2387,7 @@ objects:
           pod.beta.kubernetes.io/init-containers: |-
             [{
               "name": "openshift-ca-pemtokeystore",
-              "image": "${PEMTOKEYSTORE_IMAGE}",
+              "image": "syndesis/pemtokeystore:v0.2.1",
               "imagePullPolicy": "IfNotPresent",
               "args": [
                 "-keystore", "/tls-keystore/openshift-truststore.jks",
@@ -2410,7 +2411,7 @@ objects:
       spec:
         initContainers:
         - name: openshift-ca-pemtokeystore
-          image: ${PEMTOKEYSTORE_IMAGE}
+          image: syndesis/pemtokeystore:v0.2.1
           imagePullPolicy: IfNotPresent
           args:
           - -keystore

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -64,7 +64,7 @@ parameters:
   required: true
 - name: PEMTOKEYSTORE_IMAGE
   description: PEM to keystore init container image
-  value: jimmidyson/pemtokeystore:v0.2.0
+  value: docker.io/jimmidyson/pemtokeystore:v0.2.0
   required: true
 - name: GITHUB_OAUTH_DEFAULT_SCOPES
   description: GitHub OAuth default scopes


### PR DESCRIPTION
This is a prerequisited for properly creating tagged versions of the templates.

Also, the external registry can be set now easily.

@jimmidyson @zregvart @chirino: Would it make sense to introduce a real OpenShift template parameters "SYNDESIS_VERSION" and "SYNDESIS_REGISTRY" with the appropriate defaults (instead of filling this in during build time)? This would give some extra flexibility when instantiating the templates (but might be too flexible then). Opinions ?