### PR TITLE
(sql-stored) adding sampledb-password env parameter to syndesis-rest

### DIFF
--- a/generator/04-syndesis-rest.yml.mustache
+++ b/generator/04-syndesis-rest.yml.mustache
@@ -160,6 +160,8 @@
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -2133,6 +2133,8 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -2033,6 +2033,8 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -2037,6 +2037,8 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -2121,6 +2121,8 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -2147,6 +2147,8 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -2151,6 +2151,8 @@ objects:
             value: ${TEST_SUPPORT_ENABLED}
           - name: CONTROLLERS_INTEGRATION_ENABLED
             value: ${CONTROLLERS_INTEGRATION_ENABLED}
+          - name: POSTGRESQL_SAMPLEDB_PASSWORD
+            value: ${POSTGRESQL_SAMPLEDB_PASSWORD}
           - name: KEYCLOAK_ADMIN_USERNAME
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
So that it can be used for token replacement for an existing db-connection in our initial data load.