### PR TITLE
refactor: Introduce image stream for s2i builder

### DIFF
--- a/generator/02-syndesis-image-streams.yml.mustache
+++ b/generator/02-syndesis-image-streams.yml.mustache
@@ -14,7 +14,7 @@
         name: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Syndesis.Rest }}:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{ Tags.Syndesis }}
+      name: "{{ Tags.Syndesis }}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -29,7 +29,7 @@
         name: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Support.Keycloak }}:{{ Tags.Keycloak }}
       importPolicy:
         scheduled: true
-      name: {{ Tags.Keycloak }}
+      name: "{{ Tags.Keycloak }}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -44,7 +44,7 @@
         name: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Syndesis.Ui }}:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{ Tags.Syndesis }}
+      name: "{{ Tags.Syndesis }}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -59,7 +59,7 @@
         name: ${SYNDESIS_REGISTRY}/{{Images.AtlasMapImagesPrefix}}/{{ Images.Syndesis.Atlasmap }}:{{ Tags.Atlasmap }}
       importPolicy:
         scheduled: true
-      name: {{ Tags.Syndesis }}
+      name: "{{ Tags.Syndesis }}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -74,7 +74,7 @@
         name: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Syndesis.Verifier }}:{{ Tags.Syndesis }}
       importPolicy:
         scheduled: true
-      name: {{ Tags.Syndesis }}
+      name: "{{ Tags.Syndesis }}"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -89,7 +89,7 @@
         name: ${SYNDESIS_REGISTRY}/{{Images.SyndesisImagesPrefix}}/{{ Images.Support.PemToKeystore }}:{{ Tags.PemToKeystore }}
       importPolicy:
         scheduled: true
-      name: {{ Tags.PemToKeystore }}
+      name: "{{ Tags.PemToKeystore }}"
 {{/WithDockerImages}}
 - apiVersion: v1
   kind: ImageStream
@@ -105,5 +105,5 @@
         name: {{ Images.S2i.DockerImage }}:{{ Images.S2i.Tag }}
       importPolicy:
         scheduled: true
-      name: {{ Images.S2i.Tag }}
+      name: "{{ Images.S2i.Tag }}"
 {{/Productized}}

--- a/generator/02-syndesis-image-streams.yml.mustache
+++ b/generator/02-syndesis-image-streams.yml.mustache
@@ -91,4 +91,19 @@
         scheduled: true
       name: {{ Tags.PemToKeystore }}
 {{/WithDockerImages}}
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: {{ Images.S2i.ImageStream }}
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: {{ Images.S2i.DockerImage }}:{{ Images.S2i.Tag }}
+      importPolicy:
+        scheduled: true
+      name: {{ Images.S2i.Tag }}
 {{/Productized}}

--- a/generator/04-syndesis-rest.yml.mustache
+++ b/generator/04-syndesis-rest.yml.mustache
@@ -286,6 +286,7 @@
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: {{ Images.S2i.ImageStream }}:{{ Images.S2i.Tag }}
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/generator/syndesis-template.go
+++ b/generator/syndesis-template.go
@@ -49,9 +49,16 @@ type syndesisImages struct {
 	Atlasmap string
 }
 
+type s2iConfig struct {
+	ImageStream string
+	DockerImage string
+	Tag         string
+}
+
 type images struct {
 	Support              supportImages
 	Syndesis             syndesisImages
+	S2i                  s2iConfig
 	ImageStreamNamespace string
 	SyndesisImagesPrefix string
 	AtlasMapImagesPrefix string
@@ -96,6 +103,11 @@ var syndesisContext = Context{
 			Verifier: "syndesis-verifier",
 			Atlasmap: "atlasmap",
 		},
+		S2i: s2iConfig{
+			ImageStream: "s2i-java",
+			DockerImage: "fabric8/s2i-java",
+			Tag:         "2.0",
+		},
 	},
 	Tags: tags{
 		Postgresql:    "9.5",
@@ -120,6 +132,11 @@ var productContext = Context{
 			Ui:       "fuse-ignite-ui",
 			Verifier: "fuse-ignite-verifier",
 			Atlasmap: "fuse-ignite-mapper",
+		},
+		S2i: s2iConfig{
+			ImageStream: "fuse-ignite-java-openshift",
+			DockerImage: "jboss-fuse7-tech-preview/fuse-ignite-java-openshift",
+			Tag:         "1.0",
 		},
 	},
 	Tags: tags{

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -237,6 +237,21 @@ objects:
         scheduled: true
       name: v0.2.1
 
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: s2i-java
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: fabric8/s2i-java:2.0
+      importPolicy:
+        scheduled: true
+      name: 2.0
 
 - apiVersion: v1
   kind: Service
@@ -2295,6 +2310,7 @@ objects:
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: s2i-java:2.0
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -160,7 +160,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -175,7 +175,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
-      name: 2.5.4.Final
+      name: "2.5.4.Final"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -190,7 +190,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -205,7 +205,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -220,7 +220,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -235,7 +235,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/pemtokeystore:v0.2.1
       importPolicy:
         scheduled: true
-      name: v0.2.1
+      name: "v0.2.1"
 
 - apiVersion: v1
   kind: ImageStream
@@ -251,7 +251,7 @@ objects:
         name: fabric8/s2i-java:2.0
       importPolicy:
         scheduled: true
-      name: 2.0
+      name: "2.0"
 
 - apiVersion: v1
   kind: Service

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -143,6 +143,21 @@ message: |-
     FYI Keycloak Admin username is '${KEYCLOAK_ADMIN_USERNAME}', password '${KEYCLOAK_ADMIN_PASSWORD}'.
 objects:
 
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: s2i-java
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: fabric8/s2i-java:2.0
+      importPolicy:
+        scheduled: true
+      name: 2.0
 
 - apiVersion: v1
   kind: Service
@@ -2183,6 +2198,7 @@ objects:
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: s2i-java:2.0
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -157,7 +157,7 @@ objects:
         name: fabric8/s2i-java:2.0
       importPolicy:
         scheduled: true
-      name: 2.0
+      name: "2.0"
 
 - apiVersion: v1
   kind: Service

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -161,7 +161,7 @@ objects:
         name: fabric8/s2i-java:2.0
       importPolicy:
         scheduled: true
-      name: 2.0
+      name: "2.0"
 
 - apiVersion: v1
   kind: Service

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -147,6 +147,21 @@ message: |-
     FYI Keycloak Admin username is '${KEYCLOAK_ADMIN_USERNAME}', password '${KEYCLOAK_ADMIN_PASSWORD}'.
 objects:
 
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: s2i-java
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: fabric8/s2i-java:2.0
+      importPolicy:
+        scheduled: true
+      name: 2.0
 
 - apiVersion: v1
   kind: Service
@@ -2187,6 +2202,7 @@ objects:
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: s2i-java:2.0
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -233,6 +233,21 @@ objects:
         scheduled: true
       name: v0.2.1
 
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: s2i-java
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: fabric8/s2i-java:2.0
+      importPolicy:
+        scheduled: true
+      name: 2.0
 
 - apiVersion: v1
   kind: Service
@@ -2319,6 +2334,7 @@ objects:
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: s2i-java:2.0
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -156,7 +156,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -171,7 +171,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
-      name: 2.5.4.Final
+      name: "2.5.4.Final"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -186,7 +186,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -201,7 +201,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -216,7 +216,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -231,7 +231,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/pemtokeystore:v0.2.1
       importPolicy:
         scheduled: true
-      name: v0.2.1
+      name: "v0.2.1"
 
 - apiVersion: v1
   kind: ImageStream
@@ -247,7 +247,7 @@ objects:
         name: fabric8/s2i-java:2.0
       importPolicy:
         scheduled: true
-      name: 2.0
+      name: "2.0"
 
 - apiVersion: v1
   kind: Service

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -233,6 +233,21 @@ objects:
         scheduled: true
       name: v0.2.1
 
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: s2i-java
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: fabric8/s2i-java:2.0
+      importPolicy:
+        scheduled: true
+      name: 2.0
 
 - apiVersion: v1
   kind: Service
@@ -2345,6 +2360,7 @@ objects:
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: s2i-java:2.0
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -156,7 +156,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -171,7 +171,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
-      name: 2.5.4.Final
+      name: "2.5.4.Final"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -186,7 +186,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -201,7 +201,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -216,7 +216,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -231,7 +231,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/pemtokeystore:v0.2.1
       importPolicy:
         scheduled: true
-      name: v0.2.1
+      name: "v0.2.1"
 
 - apiVersion: v1
   kind: ImageStream
@@ -247,7 +247,7 @@ objects:
         name: fabric8/s2i-java:2.0
       importPolicy:
         scheduled: true
-      name: 2.0
+      name: "2.0"
 
 - apiVersion: v1
   kind: Service

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -237,6 +237,21 @@ objects:
         scheduled: true
       name: v0.2.1
 
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    name: s2i-java
+    labels:
+      app: syndesis
+      component: s2i-java
+  spec:
+    tags:
+    - from:
+        kind: DockerImage
+        name: fabric8/s2i-java:2.0
+      importPolicy:
+        scheduled: true
+      name: 2.0
 
 - apiVersion: v1
   kind: Service
@@ -2349,6 +2364,7 @@ objects:
       openshift:
         apiBaseUrl: ${OPENSHIFT_MASTER}/oapi/v1
         namespace: ${NAMESPACE}
+        builderImageStreamTag: s2i-java:2.0
       keycloak:
         enabled: true
         configurationFile: file:config/syndesis-client.json

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -160,7 +160,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-rest:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -175,7 +175,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/keycloak-openshift:2.5.4.Final
       importPolicy:
         scheduled: true
-      name: 2.5.4.Final
+      name: "2.5.4.Final"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -190,7 +190,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-ui:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -205,7 +205,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/atlasmap/atlasmap:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -220,7 +220,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/syndesis-verifier:latest
       importPolicy:
         scheduled: true
-      name: latest
+      name: "latest"
 - apiVersion: v1
   kind: ImageStream
   metadata:
@@ -235,7 +235,7 @@ objects:
         name: ${SYNDESIS_REGISTRY}/syndesis/pemtokeystore:v0.2.1
       importPolicy:
         scheduled: true
-      name: v0.2.1
+      name: "v0.2.1"
 
 - apiVersion: v1
   kind: ImageStream
@@ -251,7 +251,7 @@ objects:
         name: fabric8/s2i-java:2.0
       importPolicy:
         scheduled: true
-      name: 2.0
+      name: "2.0"
 
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
This stream needs to be always present, even for the -dev templates.
For the productized environment it's expected that its already setup previously.

Requires and is prerequisite for https://github.com/syndesisio/syndesis-rest/pull/675