### PR TITLE
fix: Readiness/Liveness check fixes, default config for rest extended

### DIFF
--- a/generator/04-syndesis-atlasmap.yml.mustache
+++ b/generator/04-syndesis-atlasmap.yml.mustache
@@ -145,7 +145,7 @@
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -153,7 +153,7 @@
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10{{/Probeless}}
+            initialDelaySeconds: 30{{/Probeless}}
           ports:
           - containerPort: 8080
             name: http

--- a/generator/04-syndesis-rest.yml.mustache
+++ b/generator/04-syndesis-rest.yml.mustache
@@ -174,7 +174,7 @@
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -182,7 +182,7 @@
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10{{/Probeless}}
+            initialDelaySeconds: 30{{/Probeless}}
           ports:
           - containerPort: 8080
             name: http
@@ -338,5 +338,8 @@
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: {{ Images.S2i.ImageStream }}:{{ Images.S2i.Tag }}
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -1146,6 +1146,9 @@ objects:
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: s2i-java:2.0
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
 - apiVersion: v1

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -464,7 +464,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -472,7 +472,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -918,7 +918,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -926,7 +926,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1047,6 +1047,9 @@ objects:
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: s2i-java:2.0
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
 - apiVersion: v1

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -468,7 +468,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -476,7 +476,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -922,7 +922,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -930,7 +930,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1051,6 +1051,9 @@ objects:
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: s2i-java:2.0
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
 - apiVersion: v1

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -572,7 +572,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -580,7 +580,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1027,7 +1027,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -1035,7 +1035,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1183,6 +1183,9 @@ objects:
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: s2i-java:2.0
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
 - apiVersion: v1

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -572,7 +572,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -580,7 +580,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1053,7 +1053,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -1061,7 +1061,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1209,6 +1209,9 @@ objects:
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: s2i-java:2.0
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
 - apiVersion: v1

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -576,7 +576,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -584,7 +584,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1057,7 +1057,7 @@ objects:
               command:
               - curl
               - -sSLf
-              - http://localhost:8080
+              - http://localhost:8181/health
             initialDelaySeconds: 180
           readinessProbe:
             exec:
@@ -1065,7 +1065,7 @@ objects:
               - curl
               - -sSLf
               - http://localhost:8181/health
-            initialDelaySeconds: 10
+            initialDelaySeconds: 30
           ports:
           - containerPort: 8080
             name: http
@@ -1213,6 +1213,9 @@ objects:
         namespace: ${NAMESPACE}
         imageStreamNamespace: ${IMAGE_STREAM_NAMESPACE}
         builderImageStreamTag: s2i-java:2.0
+        deploymentMemoryRequestMi: 200
+        deploymentMemoryLimitMi: 512
+        mavenOptions: "-XX:+UseG1GC -XX:+UseStringDeduplication -Xmx310m"
       dao:
         kind: jsondb
 - apiVersion: v1


### PR DESCRIPTION
* Use the same check for liveness and readiness
* Start readiness check after 30s
* Added default config for builder images