### PR TITLE
Add default route for rest-api testing

### DIFF
--- a/generator/04-syndesis-rest.yml.mustache
+++ b/generator/04-syndesis-rest.yml.mustache
@@ -26,7 +26,24 @@
       targetPort: 8080
     selector:
       app: syndesis
+      component: syndesis-rest{{#Probeless}}
+
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: syndesis
       component: syndesis-rest
+    name: syndesis-rest
+  spec:
+    host: ${ROUTE_HOSTNAME}
+    path: /api
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: syndesis-rest{{/Probeless}}
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -783,6 +783,22 @@ objects:
       app: syndesis
       component: syndesis-rest
 - apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: syndesis
+      component: syndesis-rest
+    name: syndesis-rest
+  spec:
+    host: ${ROUTE_HOSTNAME}
+    path: /api
+    tls:
+      insecureEdgeTerminationPolicy: Redirect
+      termination: edge
+    to:
+      kind: Service
+      name: syndesis-rest
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     labels:


### PR DESCRIPTION
It will be present only in the syndesis-ci template. The presence of this route would make testing for QE much much easier.