### PR TITLE
refactor: safer string concatenation in sampledb

### DIFF
--- a/generator/04-syndesis-db.yml.mustache
+++ b/generator/04-syndesis-db.yml.mustache
@@ -36,7 +36,7 @@
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;

--- a/syndesis-ci.yml
+++ b/syndesis-ci.yml
@@ -510,7 +510,7 @@ objects:
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;

--- a/syndesis-dev-restricted.yml
+++ b/syndesis-dev-restricted.yml
@@ -416,7 +416,7 @@ objects:
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;

--- a/syndesis-dev.yml
+++ b/syndesis-dev.yml
@@ -420,7 +420,7 @@ objects:
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;

--- a/syndesis-ephemeral-restricted.yml
+++ b/syndesis-ephemeral-restricted.yml
@@ -524,7 +524,7 @@ objects:
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;

--- a/syndesis-restricted.yml
+++ b/syndesis-restricted.yml
@@ -524,7 +524,7 @@ objects:
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;

--- a/syndesis.yml
+++ b/syndesis.yml
@@ -528,7 +528,7 @@ objects:
         DECLARE
           task varchar;
         BEGIN
-          task := lead_status || ' Lead: Please contact ' || first_and_last_name || ' from ' || company || ' at ' || phone || ' or ' || email || '. Lead is from ' || lead_source || '. Rating: ' || rating || '.';
+          task := concat(lead_status || ' ', 'Lead: Please contact ', first_and_last_name, ' from ' || company, ' via phone: ' || phone, ' via email: ' || email, '. ', 'Lead is from || lead_source, '. Rating: || rating, '.');
           insert into todo(task,completed) VALUES (task,0);
         END;
         $BODY$;


### PR DESCRIPTION
Changes the SQL stored procedure to formulate the content for TODO.TASK
in a NULL safe way. Any value that was NULL previously could make the
whole varchar NULL.

Fixes syndesisio/todo-example#2